### PR TITLE
Add Kendall uncertainty-weighted multi-task loss

### DIFF
--- a/team_code_transfuser/config.py
+++ b/team_code_transfuser/config.py
@@ -135,6 +135,25 @@ class GlobalConfig:
                        'loss_offset', 'loss_yaw_class', 'loss_yaw_res', 'loss_velocity', 'loss_brake']
     detailed_losses_weights = [1.0, 1.0, 1.0, 1.0, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0, 0.0]
 
+    # Uncertainty-weighted multi-task loss (Kendall et al., CVPR 2018).
+    # When True, LidarCenterNet learns one log-variance scalar per task group
+    # (wp, bev, depth, semantic, detection) and forms loss_total as
+    #   sum_i ( exp(-s_i) * L_i + 0.5 * s_i ).
+    # The per-task `detailed_losses_weights` above are still applied first, so
+    # tasks weighted to 0.0 (e.g. loss_velocity, loss_brake) contribute nothing.
+    uncertainty_weights = False
+    # Task groups used by the uncertainty-weighted loss. Each value is the list
+    # of detailed-loss keys that share a single learned log-variance.
+    uncertainty_task_groups = {
+        'wp':        ['loss_wp'],
+        'bev':       ['loss_bev'],
+        'depth':     ['loss_depth'],
+        'semantic':  ['loss_semantic'],
+        'detection': ['loss_center_heatmap', 'loss_wh', 'loss_offset',
+                      'loss_yaw_class', 'loss_yaw_res',
+                      'loss_velocity', 'loss_brake'],
+    }
+
     perception_output_features = 512 # Number of features outputted by the perception branch.
     bev_features_chanels = 64 # Number of channels for the BEV feature pyramid
     bev_upsample_factor = 2

--- a/team_code_transfuser/model.py
+++ b/team_code_transfuser/model.py
@@ -608,6 +608,73 @@ class LidarCenterNet(nn.Module):
         self.turn_controller = PIDController(K_P=config.turn_KP, K_I=config.turn_KI, K_D=config.turn_KD, n=config.turn_n)
         self.speed_controller = PIDController(K_P=config.speed_KP, K_I=config.speed_KI, K_D=config.speed_KD, n=config.speed_n)
 
+        # Optional uncertainty-weighted multi-task loss (Kendall et al., CVPR 2018).
+        # One learnable log-variance per task group declared in config. These are
+        # registered on the module (not the device explicitly) so they move with
+        # the model under DDP and are serialized inside model.state_dict().
+        self.uncertainty_weights = bool(getattr(config, 'uncertainty_weights', False))
+        self.uncertainty_task_groups = dict(getattr(config, 'uncertainty_task_groups', {}))
+        if self.uncertainty_weights:
+            self.log_vars = nn.ParameterDict({
+                name: nn.Parameter(torch.zeros(1))
+                for name in self.uncertainty_task_groups.keys()
+            }).to(self.device)
+        else:
+            self.log_vars = None
+
+    @staticmethod
+    def _uncertainty_term(loss_val, log_var):
+        # 0.5 * exp(-s) * L + 0.5 * s. The 0.5 in front of the data term is the
+        # original Kendall formulation for L1/L2 regression; the regularizer
+        # 0.5 * s is identical. Using the same 0.5 across both terms keeps the
+        # gradient w.r.t. s well-conditioned regardless of loss magnitude.
+        return 0.5 * torch.exp(-log_var) * loss_val + 0.5 * log_var
+
+    def compute_combined_loss(self, loss_dict, detailed_weights):
+        """Combine the per-task losses produced by ``forward`` into a scalar.
+
+        Args:
+            loss_dict: mapping ``loss_name -> tensor`` as returned by ``forward``.
+            detailed_weights: mapping ``loss_name -> float`` with the existing
+                hand-tuned per-task weights (e.g. ``config.detailed_losses_weights``
+                packed by ``train.py``).
+
+        Returns:
+            ``(total_loss, weighted_components)`` where ``weighted_components``
+            is a dict of detached scalars suitable for TensorBoard logging.
+            Each value equals ``detailed_weights[k] * loss_dict[k]`` so the
+            existing per-key plots remain comparable across runs.
+        """
+        device = next(iter(loss_dict.values())).device
+        weighted = {}
+        for k, v in loss_dict.items():
+            w = float(detailed_weights.get(k, 0.0))
+            weighted[k] = w * v
+
+        if not self.uncertainty_weights or self.log_vars is None:
+            total = torch.zeros((), device=device, dtype=torch.float32)
+            for v in weighted.values():
+                total = total + v
+            return total, weighted
+
+        total = torch.zeros((), device=device, dtype=torch.float32)
+        for group_name, keys in self.uncertainty_task_groups.items():
+            group_sum = torch.zeros((), device=device, dtype=torch.float32)
+            any_nonzero = False
+            for k in keys:
+                if k not in weighted:
+                    continue
+                w = float(detailed_weights.get(k, 0.0))
+                if w == 0.0:
+                    continue
+                group_sum = group_sum + weighted[k]
+                any_nonzero = True
+            if not any_nonzero:
+                continue
+            log_var = self.log_vars[group_name].squeeze()
+            total = total + self._uncertainty_term(group_sum, log_var)
+        return total, weighted
+
     def forward_gru(self, z, target_point):
         z = self.join(z)
     

--- a/team_code_transfuser/train.py
+++ b/team_code_transfuser/train.py
@@ -68,6 +68,7 @@ def main():
     parser.add_argument('--sync_batch_norm', type=int, default=0, help='0: Compute batch norm for each GPU independently, 1: Synchronize Batch norms accross GPUs. Only use with --parallel_training 1')
     parser.add_argument('--zero_redundancy_optimizer', type=int, default=0, help='0: Normal AdamW Optimizer, 1: Use Zero Reduncdancy Optimizer to reduce memory footprint. Only use with --parallel_training 1')
     parser.add_argument('--use_disk_cache', type=int, default=0, help='0: Do not cache the dataset 1: Cache the dataset on the disk pointed to by the SCRATCH enironment variable. Useful if the dataset is stored on slow HDDs and can be temporarily stored on faster SSD storage.')
+    parser.add_argument('--uncertainty_weights', type=int, default=0, help='If 1, combine per-task losses with the Kendall et al. (CVPR 2018) uncertainty-weighted multi-task formulation. Adds one learnable log-variance per task group declared in config.uncertainty_task_groups. Defaults to 0 so behavior is byte-identical to the original training loop.')
 
 
     args = parser.parse_args()
@@ -120,6 +121,7 @@ def main():
     config.n_layer = args.n_layer
     config.use_point_pillars = bool(args.use_point_pillars)
     config.backbone = args.backbone
+    config.uncertainty_weights = bool(args.uncertainty_weights)
     if(bool(args.no_bev_loss)):
         index_bev = config.detailed_losses.index("loss_bev")
         config.detailed_losses_weights[index_bev] = 0.0
@@ -300,15 +302,19 @@ class Engine(object):
         detailed_losses_epoch  = {key: 0.0 for key in self.detailed_losses}
         self.cur_epoch += 1
 
+        # Reach through DDP to the underlying LidarCenterNet for the helper.
+        inner_model = getattr(self.model, 'module', self.model)
+
         # Train loop
         for data in tqdm(self.dataloader_train):
             self.optimizer.zero_grad(set_to_none=True)
             losses = self.load_data_compute_loss(data)
-            loss = torch.tensor(0.0).to(self.device, dtype=torch.float32)
 
-            for key, value in losses.items():
-                loss += self.detailed_weights[key] * value
-                detailed_losses_epoch[key] += float(self.detailed_weights[key] * value.item())
+            loss, weighted = inner_model.compute_combined_loss(losses, self.detailed_weights)
+
+            for key, value in weighted.items():
+                detailed_losses_epoch[key] += float(value.detach().item())
+
             loss.backward()
 
             self.optimizer.step()
@@ -326,15 +332,16 @@ class Engine(object):
         loss_epoch = 0.0
         detailed_val_losses_epoch  = {key: 0.0 for key in self.detailed_losses}
 
+        inner_model = getattr(self.model, 'module', self.model)
+
         # Evaluation loop loop
         for data in tqdm(self.dataloader_val):
             losses = self.load_data_compute_loss(data)
 
-            loss = torch.tensor(0.0).to(self.device, dtype=torch.float32)
+            loss, weighted = inner_model.compute_combined_loss(losses, self.detailed_weights)
 
-            for key, value in losses.items():
-                loss += self.detailed_weights[key] * value
-                detailed_val_losses_epoch[key] += float(self.detailed_weights[key] * value.item())
+            for key, value in weighted.items():
+                detailed_val_losses_epoch[key] += float(value.detach().item())
 
             num_batches += 1
             loss_epoch += float(loss.item())


### PR DESCRIPTION
Adds an opt-in --uncertainty_weights flag that wraps the existing per-task losses with Kendall et al. (CVPR 2018):

    L_total = sum_i ( 0.5 * exp(-s_i) * w_i * L_i + 0.5 * s_i )

where s_i is one learnable log-variance per task group declared in config.uncertainty_task_groups (wp, bev, depth, semantic, detection).

- config.py: adds uncertainty_weights = False + uncertainty_task_groups dict.
- model.py:  registers an nn.ParameterDict of log-variances on LidarCenterNet (only when the flag is on) and exposes compute_combined_loss(). Parameters are part of model.state_dict() so existing load_state_dict(strict=False) calls in submission_agent keep working with old checkpoints.
- train.py:  adds the CLI flag, wires it into the config, and routes the scalar that goes into .backward() through compute_combined_loss in both train() and validate(). Per-key TensorBoard logging is unchanged so loss curves stay comparable across runs.

Behavior is byte-identical to the original training loop when the flag is 0, which keeps the M0/M1 ablations clean. The pre-existing per-task weights in detailed_losses_weights are still applied first, so a task weighted to 0.0 (e.g. loss_velocity, loss_brake) is excluded from the uncertainty sum and its log-variance receives no gradient.